### PR TITLE
Add IE11 compatibility for bundle output

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,13 @@
 {
-  "presets": ["stage-0"],
+  "presets": ["stage-0",["env", {
+    "targets": {
+      "ie": "11"
+    },
+    "modules": false
+  }]],
   "env": {
     "testing": {
-      "presets": ["stage-0", "env"]
+      "presets": ["stage-0","env"]
     }
   }
 }

--- a/bundle.es.js
+++ b/bundle.es.js
@@ -4,13 +4,17 @@ var index = {
   props: {
     mapDispatchToProps: {
       required: false,
-      default: () => ({}),
+      default: function _default() {
+        return {};
+      },
       type: Function
     },
 
     mapStateToProps: {
       required: false,
-      default: () => ({}),
+      default: function _default() {
+        return {};
+      },
       type: Function
     },
 
@@ -20,22 +24,24 @@ var index = {
     }
   },
 
-  data: ctx => ({
-    state: ctx.store.getState()
-  }),
+  data: function data(ctx) {
+    return {
+      state: ctx.store.getState()
+    };
+  },
 
-  created() {
-    this.unsubscribe = this.store.subscribe(() => {
-      this.state = this.store.getState();
+  created: function created() {
+    var _this = this;
+
+    this.unsubscribe = this.store.subscribe(function () {
+      _this.state = _this.store.getState();
     });
   },
-
-  destroyed() {
+  destroyed: function destroyed() {
     this.unsubscribe();
   },
-
-  render() {
-    const nodes = this.$scopedSlots.default(_extends({}, this.mapDispatchToProps(this.store.dispatch), this.mapStateToProps(this.state)));
+  render: function render() {
+    var nodes = this.$scopedSlots.default(_extends({}, this.mapDispatchToProps(this.store.dispatch), this.mapStateToProps(this.state)));
     if (Array.isArray(nodes)) {
       return nodes[0];
     } else {

--- a/bundle.js
+++ b/bundle.js
@@ -6,13 +6,17 @@ var index = {
   props: {
     mapDispatchToProps: {
       required: false,
-      default: () => ({}),
+      default: function _default() {
+        return {};
+      },
       type: Function
     },
 
     mapStateToProps: {
       required: false,
-      default: () => ({}),
+      default: function _default() {
+        return {};
+      },
       type: Function
     },
 
@@ -22,22 +26,24 @@ var index = {
     }
   },
 
-  data: ctx => ({
-    state: ctx.store.getState()
-  }),
+  data: function data(ctx) {
+    return {
+      state: ctx.store.getState()
+    };
+  },
 
-  created() {
-    this.unsubscribe = this.store.subscribe(() => {
-      this.state = this.store.getState();
+  created: function created() {
+    var _this = this;
+
+    this.unsubscribe = this.store.subscribe(function () {
+      _this.state = _this.store.getState();
     });
   },
-
-  destroyed() {
+  destroyed: function destroyed() {
     this.unsubscribe();
   },
-
-  render() {
-    const nodes = this.$scopedSlots.default(_extends({}, this.mapDispatchToProps(this.store.dispatch), this.mapStateToProps(this.state)));
+  render: function render() {
+    var nodes = this.$scopedSlots.default(_extends({}, this.mapDispatchToProps(this.store.dispatch), this.mapStateToProps(this.state)));
     if (Array.isArray(nodes)) {
       return nodes[0];
     } else {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "babel-core": "^6.26.3",
     "babel-jest": "^23.6.0",
+    "babel-preset-env": "^1.7.0",
     "babel-preset-stage-0": "^6.24.1",
     "husky": "^1.1.1",
     "jest": "^23.6.0",


### PR DESCRIPTION
By using babel-preset-env to specify ie11 as a target in `.babelrc`. This PR is in response to reported [issue 51](https://github.com/titouancreach/vuejs-redux/issues/51).