### PR TITLE
Ignore node_modules, example and tests in NPM 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+node_modules/
+examples/
+tests/


### PR DESCRIPTION
Because the node_modules and everything was publishing to npm that causes the package to be 130Mo.
After this PR, the size is 12Kb (seems reasonable)